### PR TITLE
fix: change output name to be plural

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ End-to-end testing is not conducted on these modules, as they are individual com
 
 | Name | Description |
 | :-- | :-- |
-| `config` | configuration for public ip's |
+| `configs` | configuration for public ip's |
 | `prefix` | configuration for public ip prefix |
 
 ## Testing

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,4 @@
-output "config" {
+output "configs" {
   description = "configuration for public ip's"
   value       = azurerm_public_ip.public
 }


### PR DESCRIPTION
## Description

This PR change the output name config to configs. Because multiple public ips can be in the output.

## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)